### PR TITLE
Added setting: Use decks for desired cards

### DIFF
--- a/Hearthstone Collection Tracker/Hearthstone Collection Tracker.csproj
+++ b/Hearthstone Collection Tracker/Hearthstone Collection Tracker.csproj
@@ -100,6 +100,7 @@
       <DependentUpon>SetSummary.xaml</DependentUpon>
     </Compile>
     <Compile Include="HearthstoneCollectionTrackerPlugin.cs" />
+    <Compile Include="Internal\CardsInDecks.cs" />
     <Compile Include="Internal\DataUpdaters\BaseUpdaterByVersion.cs" />
     <Compile Include="Internal\DataUpdaters\DataUpdaterV02.cs" />
     <Compile Include="Internal\DataUpdaters\DataUpdaterV022.cs" />

--- a/Hearthstone Collection Tracker/Hearthstone Collection Tracker.csproj
+++ b/Hearthstone Collection Tracker/Hearthstone Collection Tracker.csproj
@@ -69,6 +69,9 @@
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="QuickConverter, Version=1.2.5.0, Culture=neutral, PublicKeyToken=9c892aa7bc2af2cf, processorArchitecture=MSIL">
+      <HintPath>..\packages\QuickConverter.1.2.5\lib\net40\QuickConverter.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />

--- a/Hearthstone Collection Tracker/Hearthstone Collection Tracker.csproj
+++ b/Hearthstone Collection Tracker/Hearthstone Collection Tracker.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Internal\DataUpdaters\DataUpdaterV04.cs" />
     <Compile Include="Internal\DataUpdaters\DataUpdaterV05.cs" />
     <Compile Include="Internal\DataUpdaters\DataUpdaterV051.cs" />
+    <Compile Include="Internal\DataUpdaters\DataUpdaterV080.cs" />
     <Compile Include="Internal\DataUpdaters\DataUpdaterV071.cs" />
     <Compile Include="Internal\DataUpdaters\DataUpdaterV041.cs" />
     <Compile Include="Internal\DataUpdaters\DefaultDataUpdater.cs" />
@@ -199,8 +200,6 @@
   </ItemGroup>
   <ItemGroup>
     <Resource Include="FodyWeavers.xml" />
-    <Content Include="packages\HearthDb.dll" />
-    <Content Include="packages\HearthMirror.dll" />
     <Content Include="packages\HearthstoneDeckTracker.exe" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Hearthstone Collection Tracker/HearthstoneCollectionTrackerPlugin.cs
+++ b/Hearthstone Collection Tracker/HearthstoneCollectionTrackerPlugin.cs
@@ -75,7 +75,7 @@ namespace Hearthstone_Collection_Tracker
 
         private void HandleHearthstoneDeckDeleted(IEnumerable<Deck> decks)
         {
-            Helpers.UpdateCollection();
+            CardsInDecks.Instance.UpdateCardsInDecks();
         }
 
         private void HandleHearthstoneDeckUpdated(Deck deck)
@@ -110,7 +110,7 @@ namespace Hearthstone_Collection_Tracker
 
             if (missingCards.Any())
             {
-                Helpers.UpdateCollection();
+                CardsInDecks.Instance.UpdateCardsInDecks();
                 StringBuilder alertSB = new StringBuilder();
                 foreach (var gr in missingCards.GroupBy(c => c.Item1.Set))
                 {

--- a/Hearthstone Collection Tracker/HearthstoneCollectionTrackerPlugin.cs
+++ b/Hearthstone Collection Tracker/HearthstoneCollectionTrackerPlugin.cs
@@ -75,7 +75,7 @@ namespace Hearthstone_Collection_Tracker
 
         private void HandleHearthstoneDeckDeleted(IEnumerable<Deck> decks)
         {
-            CardsInDecks.Instance.UpdateCardsInDecks();
+            MainWindow.Refresh();
         }
 
         private void HandleHearthstoneDeckUpdated(Deck deck)
@@ -110,7 +110,7 @@ namespace Hearthstone_Collection_Tracker
 
             if (missingCards.Any())
             {
-                CardsInDecks.Instance.UpdateCardsInDecks();
+                MainWindow.Refresh();
                 StringBuilder alertSB = new StringBuilder();
                 foreach (var gr in missingCards.GroupBy(c => c.Item1.Set))
                 {

--- a/Hearthstone Collection Tracker/HearthstoneCollectionTrackerPlugin.cs
+++ b/Hearthstone Collection Tracker/HearthstoneCollectionTrackerPlugin.cs
@@ -192,7 +192,7 @@ namespace Hearthstone_Collection_Tracker
             get { return "Vasilev Konstantin & the Community"; }
         }
 
-        public static readonly Version PluginVersion = new Version(0, 7, 3);
+        public static readonly Version PluginVersion = new Version(0, 8, 0);
 
         public Version Version
         {

--- a/Hearthstone Collection Tracker/HearthstoneCollectionTrackerPlugin.cs
+++ b/Hearthstone Collection Tracker/HearthstoneCollectionTrackerPlugin.cs
@@ -43,6 +43,7 @@ namespace Hearthstone_Collection_Tracker
 
             Hearthstone_Deck_Tracker.API.DeckManagerEvents.OnDeckCreated.Add(HandleHearthstoneDeckUpdated);
             Hearthstone_Deck_Tracker.API.DeckManagerEvents.OnDeckUpdated.Add(HandleHearthstoneDeckUpdated);
+            Hearthstone_Deck_Tracker.API.DeckManagerEvents.OnDeckDeleted.Add(HandleHearthstoneDeckDeleted);
 
 			DispatcherTimer importTimer = new DispatcherTimer();
 			importTimer.Interval = new TimeSpan(0, 0, 0, 5);
@@ -72,7 +73,12 @@ namespace Hearthstone_Collection_Tracker
 
 	    }
 
-	    private void HandleHearthstoneDeckUpdated(Deck deck)
+        private void HandleHearthstoneDeckDeleted(IEnumerable<Deck> decks)
+        {
+            Helpers.UpdateCollection();
+        }
+
+        private void HandleHearthstoneDeckUpdated(Deck deck)
         {
             if (deck == null || !Settings.NotifyNewDeckMissingCards)
                 return;
@@ -104,6 +110,7 @@ namespace Hearthstone_Collection_Tracker
 
             if (missingCards.Any())
             {
+                Helpers.UpdateCollection();
                 StringBuilder alertSB = new StringBuilder();
                 foreach (var gr in missingCards.GroupBy(c => c.Item1.Set))
                 {

--- a/Hearthstone Collection Tracker/Internal/CardsInDecks.cs
+++ b/Hearthstone Collection Tracker/Internal/CardsInDecks.cs
@@ -1,0 +1,84 @@
+﻿using Hearthstone_Deck_Tracker;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+/*
+ * A Singleton class to manage how many copies of a card there are in all of
+ * the decks the user has created. Be sure to call the Update method whenever
+ * we need to refresh the deck lists.
+ */
+
+namespace Hearthstone_Collection_Tracker.Internal
+{
+    public sealed class CardsInDecks
+    {
+        private static volatile CardsInDecks instance;
+        private static object syncRoot = new Object();
+
+        private SortedDictionary<string, int> _cards;
+
+        public SortedDictionary<string, int> Cards
+        {
+            get { return _cards; }
+            set { _cards = value; }
+        }
+
+        public int CopiesInDecks(string cardName)
+        {
+            if (Cards.ContainsKey(cardName))
+            {
+                return Cards[cardName];
+            }
+
+            return 0;
+        }
+
+        private CardsInDecks()
+        {
+            this.UpdateCardsInDecks();
+        }
+
+        public static CardsInDecks Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    lock (syncRoot)
+                    {
+                        if (instance == null)
+                        {
+                            instance = new CardsInDecks();
+                        }
+                    }
+                }
+
+                return instance;
+            }
+        }
+
+        public void UpdateCardsInDecks()
+        {
+            this.Cards = new SortedDictionary<string, int>();
+            var deckList = DeckList.Instance.Decks.Where(d => !d.IsArenaDeck && !d.IsBrawlDeck).ToList();
+            foreach (var deck in deckList)
+            {
+                foreach (var card in deck.Cards)
+                {
+                    if (this.Cards.ContainsKey(card.Name))
+                    {
+                        int copiesOfCardInDeck = this.Cards[card.Name];
+                        this.Cards[card.Name] = Math.Max(card.Count, copiesOfCardInDeck);
+                    }
+                    else
+                    {
+                        this.Cards.Add(card.Name, card.Count);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Hearthstone Collection Tracker/Internal/CardsInDecks.cs
+++ b/Hearthstone Collection Tracker/Internal/CardsInDecks.cs
@@ -1,4 +1,5 @@
-﻿using Hearthstone_Deck_Tracker;
+﻿using Hearthstone_Collection_Tracker.ViewModels;
+using Hearthstone_Deck_Tracker;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -82,9 +83,11 @@ namespace Hearthstone_Collection_Tracker.Internal
             {
                 foreach (var set in HearthstoneCollectionTrackerPlugin.Settings.ActiveAccountSetsInfo)
                 {
-                    foreach (var card in set.Cards.Where(c => this.Cards.ContainsKey(c.Card.Name)))
+                    foreach (CardInCollection card in set.Cards)
                     {
-                        card.CopiesInDecks = this.Cards[card.Card.Name];
+                        CardInCollection copy = card;
+                        int index = set.Cards.IndexOf(copy);
+                        set.Cards[index].CopiesInDecks = this.Cards.Where(c => c.Key == copy.Card.Name).FirstOrDefault().Value;
                     }
                 }
             }

--- a/Hearthstone Collection Tracker/Internal/CardsInDecks.cs
+++ b/Hearthstone Collection Tracker/Internal/CardsInDecks.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 /*
  * A Singleton class to manage how many copies of a card there are in all of
@@ -19,22 +17,6 @@ namespace Hearthstone_Collection_Tracker.Internal
         private static object syncRoot = new Object();
 
         private SortedDictionary<string, int> _cards;
-
-        public SortedDictionary<string, int> Cards
-        {
-            get { return _cards; }
-            set { _cards = value; }
-        }
-
-        public int CopiesInDecks(string cardName)
-        {
-            if (Cards.ContainsKey(cardName))
-            {
-                return Cards[cardName];
-            }
-
-            return 0;
-        }
 
         private CardsInDecks()
         {
@@ -58,6 +40,22 @@ namespace Hearthstone_Collection_Tracker.Internal
 
                 return instance;
             }
+        }
+
+        public SortedDictionary<string, int> Cards
+        {
+            get { return _cards; }
+            set { _cards = value; }
+        }
+
+        public int CopiesInDecks(string cardName)
+        {
+            if (Cards.ContainsKey(cardName))
+            {
+                return Cards[cardName];
+            }
+
+            return 0;
         }
 
         public void UpdateCardsInDecks()

--- a/Hearthstone Collection Tracker/Internal/CardsInDecks.cs
+++ b/Hearthstone Collection Tracker/Internal/CardsInDecks.cs
@@ -77,6 +77,17 @@ namespace Hearthstone_Collection_Tracker.Internal
                     }
                 }
             }
+
+            if (HearthstoneCollectionTrackerPlugin.Settings != null)
+            {
+                foreach (var set in HearthstoneCollectionTrackerPlugin.Settings.ActiveAccountSetsInfo)
+                {
+                    foreach (var card in set.Cards.Where(c => this.Cards.ContainsKey(c.Card.Name)))
+                    {
+                        card.CopiesInDecks = this.Cards[card.Card.Name];
+                    }
+                }
+            }
         }
     }
 }

--- a/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV080.cs
+++ b/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV080.cs
@@ -1,0 +1,109 @@
+﻿using HearthDb.Enums;
+using Hearthstone_Deck_Tracker;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Hearthstone_Collection_Tracker.Internal.DataUpdaters
+{
+    class DataUpdaterV080 : IDataUpdater
+    {
+        private static readonly Version _version = new Version(0, 8, 0);
+
+        public Version Version => _version;
+
+        private string ConfigFilePath => Path.Combine(HearthstoneCollectionTrackerPlugin.PluginDataDir, "config.xml");
+
+        public bool RequiresUpdate
+        {
+            get
+            {
+                var configFilePath = ConfigFilePath;
+                if (!Directory.Exists(HearthstoneCollectionTrackerPlugin.PluginDataDir) || !File.Exists(configFilePath))
+                {
+                    return false;
+                }
+
+                try
+                {
+                    var settings = Hearthstone_Deck_Tracker.XmlManager<PluginSettings>.Load(configFilePath);
+                    return settings.CurrentVersion < new ModuleVersion(_version);
+                }
+                catch (Exception ex)
+                {
+                    return false;
+                }
+            }
+        }
+
+        public void PerformUpdate()
+        {
+            const string KotFTSet = "Knights of the Frozen Throne";
+            // iterate over each collection and add JtUG cards
+            foreach (var file in Directory.GetFiles(HearthstoneCollectionTrackerPlugin.PluginDataDir, "Collection_*.xml", SearchOption.TopDirectoryOnly))
+            {
+                var setInfos = XmlManager<List<BasicSetCollectionInfo>>.Load(file);
+                if (setInfos.Any(s => s.SetName == KotFTSet))
+                    continue;
+                var cards = Hearthstone_Deck_Tracker.Hearthstone.Database.GetActualCards();
+                // add JtUG cards
+                setInfos.Add(new BasicSetCollectionInfo()
+                {
+                    SetName = KotFTSet,
+                    Cards = cards.Where(c => c.Set == KotFTSet).Select(c => new CardInCollection()
+                    {
+                        AmountGolden = 0,
+                        AmountNonGolden = 0,
+                        CardId = c.Id,
+                        DesiredAmount = c.Rarity == Rarity.LEGENDARY ? 1 : 2
+                    }).ToList()
+                });
+                XmlManager<List<BasicSetCollectionInfo>>.Save(file, setInfos);
+            }
+
+            var configFilePath = ConfigFilePath;
+            var settings = XmlManager<PluginSettings>.Load(configFilePath);
+            settings.CurrentVersion = new ModuleVersion(_version);
+            XmlManager<PluginSettings>.Save(configFilePath, settings);
+        }
+
+        [Serializable]
+        public class PluginSettings
+        {
+            public ModuleVersion CurrentVersion { get; set; }
+
+            public string ActiveAccount { get; set; }
+
+            public List<AccountSummary> Accounts { get; set; }
+
+            public double CollectionWindowWidth { get; set; }
+
+            public double CollectionWindowHeight { get; set; }
+
+            public bool DefaultShowAllCards { get; set; }
+
+            public bool NotifyNewDeckMissingCards { get; set; }
+
+            public bool EnableDesiredCardsFeature { get; set; }
+        }
+
+        public class BasicSetCollectionInfo
+        {
+            public string SetName { get; set; }
+
+            public List<CardInCollection> Cards { get; set; }
+        }
+
+        public class CardInCollection
+        {
+            public int AmountNonGolden { get; set; }
+
+            public int AmountGolden { get; set; }
+
+            public int DesiredAmount { get; set; }
+
+            public string CardId { get; set; }
+        }
+    }
+}

--- a/Hearthstone Collection Tracker/Internal/Helpers.cs
+++ b/Hearthstone Collection Tracker/Internal/Helpers.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace Hearthstone_Collection_Tracker.Internal
 {
@@ -99,6 +100,13 @@ namespace Hearthstone_Collection_Tracker.Internal
             }
 
             return totalBrightness / validPixels;
+        }
+
+        public static void UpdateCollection()
+        {
+            var activeAccount = HearthstoneCollectionTrackerPlugin.Settings.ActiveAccount;
+            var fileStoragePath = HearthstoneCollectionTrackerPlugin.Settings.Accounts.Where(a => a.AccountName.Equals(activeAccount)).FirstOrDefault().FileStoragePath;
+            HearthstoneCollectionTrackerPlugin.Settings.ActiveAccountSetsInfo = SetCardsManager.LoadSetsInfo(fileStoragePath);
         }
     }
 }

--- a/Hearthstone Collection Tracker/Internal/Helpers.cs
+++ b/Hearthstone Collection Tracker/Internal/Helpers.cs
@@ -4,7 +4,6 @@ using System.Drawing;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
-using System.Linq;
 
 namespace Hearthstone_Collection_Tracker.Internal
 {

--- a/Hearthstone Collection Tracker/Internal/Helpers.cs
+++ b/Hearthstone Collection Tracker/Internal/Helpers.cs
@@ -101,12 +101,5 @@ namespace Hearthstone_Collection_Tracker.Internal
 
             return totalBrightness / validPixels;
         }
-
-        public static void UpdateCollection()
-        {
-            var activeAccount = HearthstoneCollectionTrackerPlugin.Settings.ActiveAccount;
-            var fileStoragePath = HearthstoneCollectionTrackerPlugin.Settings.Accounts.Where(a => a.AccountName.Equals(activeAccount)).FirstOrDefault().FileStoragePath;
-            HearthstoneCollectionTrackerPlugin.Settings.ActiveAccountSetsInfo = SetCardsManager.LoadSetsInfo(fileStoragePath);
-        }
     }
 }

--- a/Hearthstone Collection Tracker/Internal/PluginSettings.cs
+++ b/Hearthstone Collection Tracker/Internal/PluginSettings.cs
@@ -30,6 +30,8 @@ namespace Hearthstone_Collection_Tracker.Internal
 
 		public bool EnableAutoImport { get; set; }
 
+        public bool UseDecksForDesiredCards { get; set; }
+
         [NonSerialized]
         [XmlIgnore]
         private IList<BasicSetCollectionInfo> _activeAccountSetsInfo;

--- a/Hearthstone Collection Tracker/MainWindow.xaml
+++ b/Hearthstone Collection Tracker/MainWindow.xaml
@@ -7,6 +7,7 @@
         xmlns:DTcontrols="clr-namespace:Hearthstone_Deck_Tracker.Controls;assembly=HearthstoneDeckTracker"
         xmlns:hearthstoneDeckTracker="clr-namespace:Hearthstone_Deck_Tracker;assembly=HearthstoneDeckTracker"
         xmlns:internal="clr-namespace:Hearthstone_Collection_Tracker.Internal"
+        xmlns:qc="http://QuickConverter.CodePlex.com/"
         Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
         Icon="Internal\HSCollection.ico"
         BorderBrush="{DynamicResource AccentColorBrush}" BorderThickness="1"
@@ -125,7 +126,7 @@
                                         <ComboBox Grid.Column="1" Width="20" SelectedItem="{Binding DesiredAmount, Mode=TwoWay}" Height="25"
                                                   ToolTip="Desired amount in collection"
                                                   ItemsSource="{Binding DesiredAmountOptions, Mode=OneTime}"
-                                                  Visibility="{Binding Path=EnableDesiredCardsFeature, Source={x:Static local:HearthstoneCollectionTrackerPlugin.Settings}, Converter={StaticResource VisibilityConverter}}">
+                                                  Visibility="{qc:MultiBinding '$P0 ## !$P1 ? Visibility.Visible : Visibility.Collapsed', P0={Binding Path=EnableDesiredCardsFeature, Source={x:Static local:HearthstoneCollectionTrackerPlugin.Settings}}, P1={Binding Path=UseDecksForDesiredCards, Source={x:Static local:HearthstoneCollectionTrackerPlugin.Settings}}}">
                                         </ComboBox>
                                     </Grid>
                                 </DataTemplate>

--- a/Hearthstone Collection Tracker/MainWindow.xaml
+++ b/Hearthstone Collection Tracker/MainWindow.xaml
@@ -20,9 +20,11 @@
                 <Border Margin="5, 5, 0, 0" BorderThickness="1" BorderBrush="{DynamicResource AccentColorBrush}">
                     <DockPanel LastChildFill="True" Height="Auto">
                         <controls:ToggleSwitch x:Name="ShowOnlyMissing" IsChecked="{Binding Path=Filter.OnlyMissing, Mode=TwoWay}"
-                                           OffLabel="Show all" OnLabel="Show only missing" DockPanel.Dock="Top" Margin="10,5,5,0" />
+                                           OffLabel="Show only missing" OnLabel="Show only missing" DockPanel.Dock="Top" Margin="10,5,5,0" />
+                        <controls:ToggleSwitch x:Name="ShowOnlyDesired" IsChecked="{Binding Path=Filter.OnlyDesired, Mode=TwoWay}"
+                                           OffLabel="Show only desired" OnLabel="Show only desired" DockPanel.Dock="Top" Margin="10,5,5,0" Visibility="Collapsed" />
                         <controls:ToggleSwitch x:Name="EditingGoldenCollection" IsChecked="{Binding Path=Filter.GoldenCards, Mode=TwoWay}"
-                                           OffLabel="Non-golden" OnLabel="Golden" DockPanel.Dock="Top" Margin="10,5,5,0" />
+                                           OffLabel="Golden" OnLabel="Golden" DockPanel.Dock="Top" Margin="10,5,5,0" />
                         <TextBox controls:TextBoxHelper.Watermark="Search..." x:Name="TextBoxCollectionFilter"
                             VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                             Margin="10,5,10,0" TextWrapping="NoWrap" VerticalAlignment="Top"

--- a/Hearthstone Collection Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/MainWindow.xaml.cs
@@ -50,7 +50,7 @@ namespace Hearthstone_Collection_Tracker
 				};
 
 				string activeAccount = HearthstoneCollectionTrackerPlugin.Settings.ActiveAccount;
-                Title = "Collection Tracker";
+				Title = "Collection Tracker";
 				if(!string.IsNullOrEmpty(activeAccount))
 				{
 					Title += " (" + activeAccount + ")";

--- a/Hearthstone Collection Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/MainWindow.xaml.cs
@@ -28,11 +28,18 @@ namespace Hearthstone_Collection_Tracker
             get { return new Thickness(0, TitlebarHeight, 0, 0); }
         }
 
-        public void Refresh()
+        public static void Refresh()
         {
-            SetStats.ItemsSource = null;
-            this.GetSetsInfo();
-            SetStats.ItemsSource = this.SetsInfo;
+            if (Application.Current.Windows.OfType<MainWindow>().Any())
+            {
+                MainWindow mainWindow = Application.Current.Windows.OfType<MainWindow>().FirstOrDefault();
+                if (mainWindow.SetStats != null)
+                {
+                    mainWindow.SetStats.ItemsSource = null;
+                    mainWindow.GetSetsInfo();
+                    mainWindow.SetStats.ItemsSource = mainWindow.SetsInfo;
+                }
+            }
         }
 
         public IEnumerable<SetDetailInfoViewModel> SetsInfo { get; set; }

--- a/Hearthstone Collection Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/MainWindow.xaml.cs
@@ -317,6 +317,7 @@ namespace Hearthstone_Collection_Tracker
 
         private void GetSetsInfo()
         {
+            CardsInDecks.Instance.UpdateCardsInDecks();
             this.SetsInfo = HearthstoneCollectionTrackerPlugin.Settings.ActiveAccountSetsInfo.Select(set => new SetDetailInfoViewModel
             {
                 SetName = set.SetName,

--- a/Hearthstone Collection Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/MainWindow.xaml.cs
@@ -78,6 +78,17 @@ namespace Hearthstone_Collection_Tracker
 			}
 		}
 
+        public void Refresh()
+        {
+            SetStats.ItemsSource = null;
+            this.SetsInfo = HearthstoneCollectionTrackerPlugin.Settings.ActiveAccountSetsInfo.Select(set => new SetDetailInfoViewModel
+            {
+                SetName = set.SetName,
+                SetCards = new TrulyObservableCollection<CardInCollection>(set.Cards.ToList())
+            }).ToList();
+            SetStats.ItemsSource = this.SetsInfo;
+        }
+
         private void EditCollection(SetDetailInfoViewModel setInfo)
         {
             OpenCollectionForEditing(setInfo.SetCards);

--- a/Hearthstone Collection Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/MainWindow.xaml.cs
@@ -117,8 +117,8 @@ namespace Hearthstone_Collection_Tracker
             CardInCollection c = card as CardInCollection;
             if (Filter.OnlyDesired)
             {
-                if ((Filter.GoldenCards && c.AmountGolden >= c.DesiredAmount)
-                    || (!Filter.GoldenCards && c.AmountNonGolden >= c.DesiredAmount))
+                if ((Filter.GoldenCards && c.AmountGolden >= c.ActualDesiredAmount)
+                    || (!Filter.GoldenCards && c.AmountNonGolden >= c.ActualDesiredAmount))
                 {
                     return false;
                 }

--- a/Hearthstone Collection Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/MainWindow.xaml.cs
@@ -50,8 +50,6 @@ namespace Hearthstone_Collection_Tracker
 				};
 
 				string activeAccount = HearthstoneCollectionTrackerPlugin.Settings.ActiveAccount;
-                var fileStoragePath = HearthstoneCollectionTrackerPlugin.Settings.Accounts.Where(a => a.AccountName.Equals(activeAccount)).FirstOrDefault().FileStoragePath;
-                HearthstoneCollectionTrackerPlugin.Settings.ActiveAccountSetsInfo = SetCardsManager.LoadSetsInfo(fileStoragePath);
                 Title = "Collection Tracker";
 				if(!string.IsNullOrEmpty(activeAccount))
 				{

--- a/Hearthstone Collection Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/MainWindow.xaml.cs
@@ -28,6 +28,17 @@ namespace Hearthstone_Collection_Tracker
             get { return new Thickness(0, TitlebarHeight, 0, 0); }
         }
 
+        public void Refresh()
+        {
+            SetStats.ItemsSource = null;
+            this.SetsInfo = HearthstoneCollectionTrackerPlugin.Settings.ActiveAccountSetsInfo.Select(set => new SetDetailInfoViewModel
+            {
+                SetName = set.SetName,
+                SetCards = new TrulyObservableCollection<CardInCollection>(set.Cards.ToList())
+            }).ToList();
+            SetStats.ItemsSource = this.SetsInfo;
+        }
+
         public IEnumerable<SetDetailInfoViewModel> SetsInfo { get; set; }
 
         public MainWindow()
@@ -77,17 +88,6 @@ namespace Hearthstone_Collection_Tracker
 				}
 			}
 		}
-
-        public void Refresh()
-        {
-            SetStats.ItemsSource = null;
-            this.SetsInfo = HearthstoneCollectionTrackerPlugin.Settings.ActiveAccountSetsInfo.Select(set => new SetDetailInfoViewModel
-            {
-                SetName = set.SetName,
-                SetCards = new TrulyObservableCollection<CardInCollection>(set.Cards.ToList())
-            }).ToList();
-            SetStats.ItemsSource = this.SetsInfo;
-        }
 
         private void EditCollection(SetDetailInfoViewModel setInfo)
         {

--- a/Hearthstone Collection Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/MainWindow.xaml.cs
@@ -55,7 +55,11 @@ namespace Hearthstone_Collection_Tracker
 				{
 					Title += " (" + activeAccount + ")";
 				}
-			}
+
+                // Setup Quick Converter.
+                QuickConverter.EquationTokenizer.AddNamespace(typeof(object));
+                QuickConverter.EquationTokenizer.AddNamespace(typeof(Visibility));
+            }
 			catch(Exception e)
 			{
 				var f = MessageBox.Show("Your Collection config file seems to be corrupted or out of date. \nReset it now?\n sorry for any inconvenience.", "Hearthstone Collection Tracker", MessageBoxButton.YesNo);

--- a/Hearthstone Collection Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/MainWindow.xaml.cs
@@ -31,11 +31,7 @@ namespace Hearthstone_Collection_Tracker
         public void Refresh()
         {
             SetStats.ItemsSource = null;
-            this.SetsInfo = HearthstoneCollectionTrackerPlugin.Settings.ActiveAccountSetsInfo.Select(set => new SetDetailInfoViewModel
-            {
-                SetName = set.SetName,
-                SetCards = new TrulyObservableCollection<CardInCollection>(set.Cards.ToList())
-            }).ToList();
+            this.GetSetsInfo();
             SetStats.ItemsSource = this.SetsInfo;
         }
 
@@ -45,11 +41,7 @@ namespace Hearthstone_Collection_Tracker
         {
 	        try
 	        {
-				SetsInfo = HearthstoneCollectionTrackerPlugin.Settings.ActiveAccountSetsInfo.Select(set => new SetDetailInfoViewModel
-				{
-					SetName = set.SetName,
-					SetCards = new TrulyObservableCollection<CardInCollection>(set.Cards.ToList())
-				});
+				this.GetSetsInfo();
 
 				this.MaxHeight = SystemParameters.PrimaryScreenHeight;
 				InitializeComponent();
@@ -321,6 +313,15 @@ namespace Hearthstone_Collection_Tracker
 
             MainWrapPanel.HorizontalAlignment = FlyoutCollection.IsOpen
                 ? HorizontalAlignment.Left : HorizontalAlignment.Center;
+        }
+
+        private void GetSetsInfo()
+        {
+            this.SetsInfo = HearthstoneCollectionTrackerPlugin.Settings.ActiveAccountSetsInfo.Select(set => new SetDetailInfoViewModel
+            {
+                SetName = set.SetName,
+                SetCards = new TrulyObservableCollection<CardInCollection>(set.Cards.ToList())
+            }).ToList();
         }
 
         private void ManageAllCards_Click(object sender, RoutedEventArgs e)

--- a/Hearthstone Collection Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/MainWindow.xaml.cs
@@ -104,6 +104,14 @@ namespace Hearthstone_Collection_Tracker
         private bool CardsFilter(object card)
         {
             CardInCollection c = card as CardInCollection;
+            if (Filter.OnlyDesired)
+            {
+                if ((Filter.GoldenCards && c.AmountGolden >= c.DesiredAmount)
+                    || (!Filter.GoldenCards && c.AmountNonGolden >= c.DesiredAmount))
+                {
+                    return false;
+                }
+            }
             if (Filter.OnlyMissing)
             {
                 if ((Filter.GoldenCards && c.AmountGolden >= c.MaxAmountInCollection)
@@ -294,6 +302,9 @@ namespace Hearthstone_Collection_Tracker
 
         private void FlyoutCollection_OnIsOpenChanged(object sender, RoutedEventArgs e)
         {
+            // Change Show Desired filter settings
+            ShowOnlyDesired.Visibility = HearthstoneCollectionTrackerPlugin.Settings.EnableDesiredCardsFeature ? Visibility.Visible : Visibility.Collapsed;
+
             if (FlyoutCollection.IsOpen)
                 TextBoxCollectionFilter.Focus();
 

--- a/Hearthstone Collection Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/MainWindow.xaml.cs
@@ -50,7 +50,9 @@ namespace Hearthstone_Collection_Tracker
 				};
 
 				string activeAccount = HearthstoneCollectionTrackerPlugin.Settings.ActiveAccount;
-				Title = "Collection Tracker";
+                var fileStoragePath = HearthstoneCollectionTrackerPlugin.Settings.Accounts.Where(a => a.AccountName.Equals(activeAccount)).FirstOrDefault().FileStoragePath;
+                HearthstoneCollectionTrackerPlugin.Settings.ActiveAccountSetsInfo = SetCardsManager.LoadSetsInfo(fileStoragePath);
+                Title = "Collection Tracker";
 				if(!string.IsNullOrEmpty(activeAccount))
 				{
 					Title += " (" + activeAccount + ")";

--- a/Hearthstone Collection Tracker/Properties/AssemblyInfo.cs
+++ b/Hearthstone Collection Tracker/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.3.0")]
-[assembly: AssemblyFileVersion("0.7.3.0")]
+[assembly: AssemblyVersion("0.8.0.0")]
+[assembly: AssemblyFileVersion("0.8.0.0")]

--- a/Hearthstone Collection Tracker/SetCardsManager.cs
+++ b/Hearthstone Collection Tracker/SetCardsManager.cs
@@ -10,9 +10,9 @@ namespace Hearthstone_Collection_Tracker
 {
     internal static class SetCardsManager
     {
-        public static readonly string[] CollectableSets = { "Classic", "Goblins vs Gnomes", "The Grand Tournament", "Whispers of the Old Gods", "Mean Streets of Gadgetzan", "Journey to Un'Goro" };
+        public static readonly string[] CollectableSets = { "Classic", "Goblins vs Gnomes", "The Grand Tournament", "Whispers of the Old Gods", "Mean Streets of Gadgetzan", "Journey to Un'Goro", "Knights of the Frozen Throne" };
 
-        public static readonly string[] StandardSets = { "Classic", "Whispers of the Old Gods", "Mean Streets of Gadgetzan", "Journey to Un'Goro" };
+        public static readonly string[] StandardSets = { "Classic", "Whispers of the Old Gods", "Mean Streets of Gadgetzan", "Journey to Un'Goro", "Knights of the Frozen Throne" };
 
         public static List<BasicSetCollectionInfo> LoadSetsInfo(string collectionStoragePath)
         {

--- a/Hearthstone Collection Tracker/SetCardsManager.cs
+++ b/Hearthstone Collection Tracker/SetCardsManager.cs
@@ -23,11 +23,11 @@ namespace Hearthstone_Collection_Tracker
                 if (setInfos != null)
                 {
                     var cards = Database.GetActualCards();
+                    var cardsInDecks = GetCardsInDecks();
                     collection = setInfos;
                     foreach (var set in CollectableSets)
                     {
                         var currentSetCards = cards.Where(c => c.Set.Equals(set, StringComparison.InvariantCultureIgnoreCase));
-                        var cardsInDecks = GetCardsInDecks();
                         var setInfo = setInfos.FirstOrDefault(si => si.SetName.Equals(set, StringComparison.InvariantCultureIgnoreCase));
                         if (setInfo == null)
                         {
@@ -51,6 +51,7 @@ namespace Hearthstone_Collection_Tracker
                                     savedCard.Card = card;
                                     savedCard.AmountGolden = savedCard.AmountGolden.Clamp(0, savedCard.MaxAmountInCollection);
                                     savedCard.AmountNonGolden = savedCard.AmountNonGolden.Clamp(0, savedCard.MaxAmountInCollection);
+                                    savedCard.CopiesInDecks = cardsInDecks.ContainsKey(card.Name) ? cardsInDecks[card.Name] : 0;
                                 }
                             }
                         }

--- a/Hearthstone Collection Tracker/SettingsWindow.xaml
+++ b/Hearthstone Collection Tracker/SettingsWindow.xaml
@@ -8,7 +8,7 @@
         xmlns:system="clr-namespace:System;assembly=mscorlib"
         mc:Ignorable="d"
         Icon="Internal\HSCollection.ico"
-        Title="Settings" Width="350" Height="313.473">
+        Title="Settings" Width="350" Height="325">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -78,10 +78,15 @@
         <CheckBox x:Name="CheckboxEnableDesiredCardsFeature" IsChecked="{Binding Path=Settings.EnableDesiredCardsFeature, Mode=TwoWay}"
                   Content="Use desired cards"
                   ToolTip="Controls visibility of Desired Cards feature"
+                  HorizontalAlignment="Left" Margin="10,5,0,0" VerticalAlignment="Top" Checked="CheckboxEnableDesiredCardsFeature_Checked" Unchecked="CheckboxEnableDesiredCardsFeature_Unchecked"/>
+        <CheckBox x:Name="CheckBoxUseDecksForDesiredCards" IsChecked="{Binding Path=Settings.UseDecksForDesiredCards, Mode=TwoWay}"
+                  Content="Use decks for determining desired cards"
+                  IsEnabled="False"
+                  ToolTip="Use cards missing from your decks as your Desired Cards instead of all cards not in your collection."
                   HorizontalAlignment="Left" Margin="10,5,0,0" VerticalAlignment="Top"/>
-        <CheckBox x:Name="checkBoxEnableAutoImport" IsChecked="{Binding Path=Settings.EnableAutoImport, Mode=TwoWay}"
-                  Content="Enable Continuous Importing"
-                  ToolTip="Will import every 5 seconds while in the collection. It is not recommended to run this with multiple accounts/regions."
-                  HorizontalAlignment="Left" Margin="10,5,0,0" VerticalAlignment="Top"/>
+        <CheckBox x:Name="checkBoxEnableAutoImport" IsChecked="{Binding Settings.EnableAutoImport, Mode=TwoWay}"
+            Content="Enable Continuous Importing"
+            ToolTip="Will import every 5 seconds while in the collection. It is not recommended to run this with multiple accounts/regions."
+            HorizontalAlignment="Left" Margin="10,5,0,0" VerticalAlignment="Top"/>
     </StackPanel>
 </controls:MetroWindow>

--- a/Hearthstone Collection Tracker/SettingsWindow.xaml
+++ b/Hearthstone Collection Tracker/SettingsWindow.xaml
@@ -83,7 +83,7 @@
                   Content="Use decks for determining desired cards"
                   IsEnabled="False"
                   ToolTip="Use cards missing from your decks as your Desired Cards instead of all cards not in your collection."
-                  HorizontalAlignment="Left" Margin="10,5,0,0" VerticalAlignment="Top"/>
+                  HorizontalAlignment="Left" Margin="10,5,0,0" VerticalAlignment="Top" Checked="UpdateMainWindow" Unchecked="UpdateMainWindow"/>
         <CheckBox x:Name="checkBoxEnableAutoImport" IsChecked="{Binding Settings.EnableAutoImport, Mode=TwoWay}"
             Content="Enable Continuous Importing"
             ToolTip="Will import every 5 seconds while in the collection. It is not recommended to run this with multiple accounts/regions."

--- a/Hearthstone Collection Tracker/SettingsWindow.xaml
+++ b/Hearthstone Collection Tracker/SettingsWindow.xaml
@@ -79,7 +79,7 @@
                   Content="Use desired cards"
                   ToolTip="Controls visibility of Desired Cards feature"
                   HorizontalAlignment="Left" Margin="10,5,0,0" VerticalAlignment="Top" Checked="CheckboxEnableDesiredCardsFeature_Checked" Unchecked="CheckboxEnableDesiredCardsFeature_Unchecked"/>
-        <CheckBox x:Name="CheckBoxUseDecksForDesiredCards" IsChecked="{Binding Path=Settings.UseDecksForDesiredCards, Mode=TwoWay}"
+        <CheckBox x:Name="CheckboxUseDecksForDesiredCards" IsChecked="{Binding Path=Settings.UseDecksForDesiredCards, Mode=TwoWay}"
                   Content="Use decks for determining desired cards"
                   IsEnabled="False"
                   ToolTip="Use cards missing from your decks as your Desired Cards instead of all cards not in your collection."

--- a/Hearthstone Collection Tracker/SettingsWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/SettingsWindow.xaml.cs
@@ -154,6 +154,15 @@ namespace Hearthstone_Collection_Tracker
 					}
 					else
 					{
+						// keep desired amount
+						foreach(var card in set.Cards)
+						{
+							var existingCardInfo = existingSet.Cards.FirstOrDefault(c => c.CardId == card.CardId);
+							if(existingCardInfo != null)
+							{
+								card.DesiredAmount = existingCardInfo.DesiredAmount;
+							}
+						}
 						existingSet.Cards = set.Cards;
 					}
 				}

--- a/Hearthstone Collection Tracker/SettingsWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/SettingsWindow.xaml.cs
@@ -210,11 +210,7 @@ namespace Hearthstone_Collection_Tracker
 
         private void UpdateMainWindow(object sender, RoutedEventArgs e)
         {
-            if (Application.Current.Windows.OfType<MainWindow>().Any())
-            {
-                MainWindow mainWindow = Application.Current.Windows.OfType<MainWindow>().FirstOrDefault();
-                mainWindow.Refresh();
-            }
+            MainWindow.Refresh();
         }
     }
 }

--- a/Hearthstone Collection Tracker/SettingsWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/SettingsWindow.xaml.cs
@@ -38,6 +38,7 @@ namespace Hearthstone_Collection_Tracker
             this.DataContext = this;
             var setsOption = SetCardsManager.CollectableSets.Select(s => new KeyValuePair<string, string>(s, s)).ToList();
             setsOption.Insert(0, new KeyValuePair<string, string>("All", null));
+            CheckBoxUseDecksForDesiredCards.IsEnabled = CheckboxEnableDesiredCardsFeature.IsChecked.Value;
         }
 
         private void UpdateAccountsComboBox()
@@ -183,6 +184,16 @@ namespace Hearthstone_Collection_Tracker
 
                 UpdateAccountsComboBox();
             }
+        }
+
+        private void CheckboxEnableDesiredCardsFeature_Checked(object sender, RoutedEventArgs e)
+        {
+            CheckBoxUseDecksForDesiredCards.IsEnabled = true;
+        }
+
+        private void CheckboxEnableDesiredCardsFeature_Unchecked(object sender, RoutedEventArgs e)
+        {
+            CheckBoxUseDecksForDesiredCards.IsEnabled = false;
         }
     }
 }

--- a/Hearthstone Collection Tracker/SettingsWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/SettingsWindow.xaml.cs
@@ -38,7 +38,7 @@ namespace Hearthstone_Collection_Tracker
             this.DataContext = this;
             var setsOption = SetCardsManager.CollectableSets.Select(s => new KeyValuePair<string, string>(s, s)).ToList();
             setsOption.Insert(0, new KeyValuePair<string, string>("All", null));
-            CheckBoxUseDecksForDesiredCards.IsEnabled = CheckboxEnableDesiredCardsFeature.IsChecked.Value;
+            CheckboxUseDecksForDesiredCards.IsEnabled = CheckboxEnableDesiredCardsFeature.IsChecked.Value;
         }
 
         private void UpdateAccountsComboBox()
@@ -195,14 +195,17 @@ namespace Hearthstone_Collection_Tracker
             }
         }
 
+        // Only enable Use Decks option if Desired Cards are enabled
         private void CheckboxEnableDesiredCardsFeature_Checked(object sender, RoutedEventArgs e)
         {
-            CheckBoxUseDecksForDesiredCards.IsEnabled = true;
+            CheckboxUseDecksForDesiredCards.IsEnabled = true;
         }
 
+        // If we uncheck Desired Cards we need to also clear the Use Decks option
         private void CheckboxEnableDesiredCardsFeature_Unchecked(object sender, RoutedEventArgs e)
         {
-            CheckBoxUseDecksForDesiredCards.IsEnabled = false;
+            CheckboxUseDecksForDesiredCards.IsEnabled = false;
+            CheckboxUseDecksForDesiredCards.IsChecked = false;
         }
     }
 }

--- a/Hearthstone Collection Tracker/SettingsWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/SettingsWindow.xaml.cs
@@ -207,5 +207,14 @@ namespace Hearthstone_Collection_Tracker
             CheckboxUseDecksForDesiredCards.IsEnabled = false;
             CheckboxUseDecksForDesiredCards.IsChecked = false;
         }
+
+        private void UpdateMainWindow(object sender, RoutedEventArgs e)
+        {
+            if (Application.Current.Windows.OfType<MainWindow>().Any())
+            {
+                MainWindow mainWindow = Application.Current.Windows.OfType<MainWindow>().FirstOrDefault();
+                mainWindow.Refresh();
+            }
+        }
     }
 }

--- a/Hearthstone Collection Tracker/SettingsWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/SettingsWindow.xaml.cs
@@ -153,15 +153,6 @@ namespace Hearthstone_Collection_Tracker
 					}
 					else
 					{
-						// keep desired amount
-						foreach(var card in set.Cards)
-						{
-							var existingCardInfo = existingSet.Cards.FirstOrDefault(c => c.CardId == card.CardId);
-							if(existingCardInfo != null)
-							{
-								card.DesiredAmount = existingCardInfo.DesiredAmount;
-							}
-						}
 						existingSet.Cards = set.Cards;
 					}
 				}

--- a/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
+++ b/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
@@ -17,11 +17,23 @@ namespace Hearthstone_Collection_Tracker.ViewModels
         public CardInCollection(Card card, int amountNonGolden = 0, int amountGolden = 0)
         {
             Card = card;
-            CardId = card.Id;
             AmountNonGolden = amountNonGolden;
             AmountGolden = amountGolden;
             CopiesInDecks = CardsInDecks.Instance.CopiesInDecks(card.Name);
             DesiredAmount = MaxAmountInCollection;
+            CardId = card.Id;
+        }
+
+        public static bool? SettingUseDecksForDesiredCards
+        {
+            get
+            {
+                if (HearthstoneCollectionTrackerPlugin.Settings == null)
+                {
+                    return null;
+                }
+                return HearthstoneCollectionTrackerPlugin.Settings.UseDecksForDesiredCards;
+            }
         }
 
         [XmlIgnore]
@@ -63,18 +75,6 @@ namespace Hearthstone_Collection_Tracker.ViewModels
             }
         }
 
-        public static bool? SettingUseDecksForDesiredCards
-        {
-            get
-            {
-                if (HearthstoneCollectionTrackerPlugin.Settings == null)
-                {
-                    return null;
-                }
-                return HearthstoneCollectionTrackerPlugin.Settings.UseDecksForDesiredCards;
-            }
-        }
-
         public int ActualDesiredAmount
         {
             get
@@ -109,14 +109,11 @@ namespace Hearthstone_Collection_Tracker.ViewModels
 
         public int DesiredAmount
         {
-            get
-            {
-                return _desiredAmount;
-            }
+            get { return _desiredAmount; }
             set
             {
                 _desiredAmount = value;
-                OnPropertyChanged("DesiredAmount");
+                OnPropertyChanged();
             }
         }
 

--- a/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
+++ b/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
@@ -19,6 +19,7 @@ namespace Hearthstone_Collection_Tracker.ViewModels
             CopiesInDecks = copiesInDecks;
             AmountNonGolden = amountNonGolden;
             AmountGolden = amountGolden;
+            DesiredAmount = MaxAmountInCollection;
             CardId = card.Id;
         }
 
@@ -76,6 +77,8 @@ namespace Hearthstone_Collection_Tracker.ViewModels
             }
         }
 
+        private int _desiredAmount;
+
         public int DesiredAmount
         {
             get
@@ -86,8 +89,13 @@ namespace Hearthstone_Collection_Tracker.ViewModels
                 }
                 else
                 {
-                    return MaxAmountInCollection;
+                    return _desiredAmount;
                 }
+            }
+            set
+            {
+                _desiredAmount = value;
+                OnPropertyChanged();
             }
         }
 

--- a/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
+++ b/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
@@ -1,12 +1,12 @@
-﻿using HearthDb.Enums;
+﻿using Hearthstone_Deck_Tracker.Hearthstone;
 using Hearthstone_Collection_Tracker.Internal;
-using Hearthstone_Deck_Tracker.Hearthstone;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Xml.Serialization;
+using HearthDb.Enums;
 
 namespace Hearthstone_Collection_Tracker.ViewModels
 {

--- a/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
+++ b/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
@@ -80,9 +80,7 @@ namespace Hearthstone_Collection_Tracker.ViewModels
         {
             get
             {
-                // TODO: Make this variable a setting
-                bool useDecksForDesired = true;
-                if (useDecksForDesired)
+                if (HearthstoneCollectionTrackerPlugin.Settings.UseDecksForDesiredCards)
                 {
                     return CopiesInDecks;
                 }

--- a/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
+++ b/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
@@ -1,11 +1,12 @@
-﻿using Hearthstone_Deck_Tracker.Hearthstone;
+﻿using HearthDb.Enums;
+using Hearthstone_Collection_Tracker.Internal;
+using Hearthstone_Deck_Tracker.Hearthstone;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Xml.Serialization;
-using HearthDb.Enums;
 
 namespace Hearthstone_Collection_Tracker.ViewModels
 {
@@ -13,14 +14,14 @@ namespace Hearthstone_Collection_Tracker.ViewModels
     {
         public CardInCollection() { }
 
-        public CardInCollection(Card card, int copiesInDecks, int amountNonGolden = 0, int amountGolden = 0)
+        public CardInCollection(Card card, int amountNonGolden = 0, int amountGolden = 0)
         {
             Card = card;
-            CopiesInDecks = copiesInDecks;
+            CardId = card.Id;
             AmountNonGolden = amountNonGolden;
             AmountGolden = amountGolden;
+            CopiesInDecks = CardsInDecks.Instance.CopiesInDecks(card.Name);
             DesiredAmount = MaxAmountInCollection;
-            CardId = card.Id;
         }
 
         [XmlIgnore]

--- a/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
+++ b/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
@@ -75,6 +75,21 @@ namespace Hearthstone_Collection_Tracker.ViewModels
             }
         }
 
+        public int ActualDesiredAmount
+        {
+            get
+            {
+                if (SettingUseDecksForDesiredCards != null && (bool)SettingUseDecksForDesiredCards)
+                {
+                    return CopiesInDecks;
+                }
+                else
+                {
+                    return DesiredAmount;
+                }
+            }
+        }
+
         public static int GetMaxAmountInCollection(Rarity rarity)
         {
             return rarity == Rarity.LEGENDARY ? 1 : 2;
@@ -96,29 +111,12 @@ namespace Hearthstone_Collection_Tracker.ViewModels
         {
             get
             {
-                // If we're using decks then the user's custom desired amount won't be used
-                if (HearthstoneCollectionTrackerPlugin.Settings.UseDecksForDesiredCards)
-                {
-                    return CopiesInDecks;
-                }
-                else
-                {
-                    return _desiredAmount;
-                }
+                return _desiredAmount;
             }
             set
             {
-                /*
-                 * Make sure we don't overwrite the user's desired amounts with
-                 * copies in decks.
-                 * If the setting is null, that means we're starting the
-                 * initial load, which will be the user's actual desired values.
-                 */
-                if (SettingUseDecksForDesiredCards == null || !(bool)SettingUseDecksForDesiredCards)
-                {
-                    _desiredAmount = value;
-                    OnPropertyChanged();
-                }
+                _desiredAmount = value;
+                OnPropertyChanged("DesiredAmount");
             }
         }
 

--- a/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
+++ b/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
@@ -13,12 +13,12 @@ namespace Hearthstone_Collection_Tracker.ViewModels
     {
         public CardInCollection() { }
 
-        public CardInCollection(Card card, int amountNonGolden = 0, int amountGolden = 0)
+        public CardInCollection(Card card, int copiesInDecks, int amountNonGolden = 0, int amountGolden = 0)
         {
             Card = card;
+            CopiesInDecks = copiesInDecks;
             AmountNonGolden = amountNonGolden;
             AmountGolden = amountGolden;
-            DesiredAmount = MaxAmountInCollection;
             CardId = card.Id;
         }
 
@@ -49,6 +49,18 @@ namespace Hearthstone_Collection_Tracker.ViewModels
             }
         }
 
+        private int _copiesInDecks;
+
+        public int CopiesInDecks
+        {
+            get { return _copiesInDecks; }
+            set
+            {
+                _copiesInDecks = value;
+                OnPropertyChanged();
+            }
+        }
+
         public static int GetMaxAmountInCollection(Rarity rarity)
         {
             return rarity == Rarity.LEGENDARY ? 1 : 2;
@@ -64,15 +76,20 @@ namespace Hearthstone_Collection_Tracker.ViewModels
             }
         }
 
-        private int _desiredAmount;
-
         public int DesiredAmount
         {
-            get { return _desiredAmount; }
-            set
+            get
             {
-                _desiredAmount = value;
-                OnPropertyChanged();
+                // TODO: Make this variable a setting
+                bool useDecksForDesired = true;
+                if (useDecksForDesired)
+                {
+                    return CopiesInDecks;
+                }
+                else
+                {
+                    return MaxAmountInCollection;
+                }
             }
         }
 

--- a/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
+++ b/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
@@ -63,6 +63,18 @@ namespace Hearthstone_Collection_Tracker.ViewModels
             }
         }
 
+        public static bool? SettingUseDecksForDesiredCards
+        {
+            get
+            {
+                if (HearthstoneCollectionTrackerPlugin.Settings == null)
+                {
+                    return null;
+                }
+                return HearthstoneCollectionTrackerPlugin.Settings.UseDecksForDesiredCards;
+            }
+        }
+
         public static int GetMaxAmountInCollection(Rarity rarity)
         {
             return rarity == Rarity.LEGENDARY ? 1 : 2;
@@ -84,6 +96,7 @@ namespace Hearthstone_Collection_Tracker.ViewModels
         {
             get
             {
+                // If we're using decks then the user's custom desired amount won't be used
                 if (HearthstoneCollectionTrackerPlugin.Settings.UseDecksForDesiredCards)
                 {
                     return CopiesInDecks;
@@ -95,8 +108,17 @@ namespace Hearthstone_Collection_Tracker.ViewModels
             }
             set
             {
-                _desiredAmount = value;
-                OnPropertyChanged();
+                /*
+                 * Make sure we don't overwrite the user's desired amounts with
+                 * copies in decks.
+                 * If the setting is null, that means we're starting the
+                 * initial load, which will be the user's actual desired values.
+                 */
+                if (SettingUseDecksForDesiredCards == null || !(bool)SettingUseDecksForDesiredCards)
+                {
+                    _desiredAmount = value;
+                    OnPropertyChanged();
+                }
             }
         }
 

--- a/Hearthstone Collection Tracker/ViewModels/FilterSettings.cs
+++ b/Hearthstone Collection Tracker/ViewModels/FilterSettings.cs
@@ -10,9 +10,26 @@ namespace Hearthstone_Collection_Tracker.ViewModels
         public FilterSettings()
         {
             OnlyMissing = true;
+            OnlyDesired = false;
             GoldenCards = false;
             Text = string.Empty;
         }
+
+        private bool _onlyDesired;
+
+        public bool OnlyDesired
+        {
+            get
+            {
+                return _onlyDesired;
+            }
+            set
+            {
+                _onlyDesired = value;
+                OnPropertyChanged();
+            }
+        }
+
 
         private bool _onlyMissing;
 

--- a/Hearthstone Collection Tracker/ViewModels/SetDetailInfoViewModel.cs
+++ b/Hearthstone Collection Tracker/ViewModels/SetDetailInfoViewModel.cs
@@ -205,17 +205,17 @@ new Dictionary<CRarity, int>
 
             foreach(var card in cards)
             {
-                TotalDesiredAmount += card.DesiredAmount;
+                TotalDesiredAmount += card.ActualDesiredAmount;
                 TotalAmount += card.MaxAmountInCollection;
                 PlayerHas += card.AmountNonGolden;
                 PlayerHasGolden += card.AmountGolden;
-                PlayerHasDesired += Math.Min(card.AmountGolden + card.AmountNonGolden, card.DesiredAmount);
+                PlayerHasDesired += Math.Min(card.AmountGolden + card.AmountNonGolden, card.ActualDesiredAmount);
             }
             MissingDesiredAmount = TotalDesiredAmount - PlayerHasDesired;
 
             OpenGoldenOdds = CalculateOpeningOdds(cards, card => card.MaxAmountInCollection - card.AmountGolden, GoldenCardProbabilities);
             OpenNonGoldenOdds = CalculateOpeningOdds(cards, card => card.MaxAmountInCollection - card.AmountNonGolden, CardProbabilities);
-            OpenDesiredOdds = CalculateOpeningOdds(cards, card => Math.Max(0, card.DesiredAmount - (card.AmountGolden + card.AmountNonGolden)), AllCardProbabilitiesByRarity);
+            OpenDesiredOdds = CalculateOpeningOdds(cards, card => Math.Max(0, card.ActualDesiredAmount - (card.AmountGolden + card.AmountNonGolden)), AllCardProbabilitiesByRarity);
         }
 
         private const int CARDS_IN_PACK = 5;

--- a/Hearthstone Collection Tracker/ViewModels/SetDetailInfoViewModel.cs
+++ b/Hearthstone Collection Tracker/ViewModels/SetDetailInfoViewModel.cs
@@ -288,7 +288,7 @@ new Dictionary<CRarity, int>
                     var currentRarity = group.Key;
                     int maxCardsAmount = group.Sum(c => c.MaxAmountInCollection);
 
-                    int disenchantingCards = group.Sum(c => Math.Min(c.AmountGolden + c.AmountNonGolden + (c.MaxAmountInCollection - c.DesiredAmount), c.MaxAmountInCollection));
+                    int disenchantingCards = group.Sum(c => Math.Min(c.AmountGolden + c.AmountNonGolden + (c.MaxAmountInCollection - c.ActualDesiredAmount), c.MaxAmountInCollection));
                     double nonGoldenAverageValue = ((double)disenchantingCards / maxCardsAmount)
                         * CardDisenchantValue[currentRarity] * CardProbabilities[currentRarity];
                     double goldenAverageValue = ((double)disenchantingCards / maxCardsAmount)

--- a/Hearthstone Collection Tracker/ViewModels/SetDetailInfoViewModel.cs
+++ b/Hearthstone Collection Tracker/ViewModels/SetDetailInfoViewModel.cs
@@ -248,14 +248,27 @@ new Dictionary<CRarity, int>
                 foreach (var group in _cards.GroupBy(c => c.Card.Rarity))
                 {
                     var currentRarity = group.Key;
-                    int maxCardsAmount = group.Sum(c => c.MaxAmountInCollection);
 
-                    int havingNonGolden = group.Sum(c => c.AmountNonGolden);
-                    double nonGoldenAverageValue = ((double)havingNonGolden / maxCardsAmount)
+                    int maxCardsAmount = 0;
+                    int havingNonGolden = 0;
+                    int havingGolden = 0;
+                    if (HearthstoneCollectionTrackerPlugin.Settings.UseDecksForDesiredCards)
+                    {
+                        maxCardsAmount = group.Sum(c => c.CopiesInDecks);
+                        havingNonGolden = group.Where(c => c.CopiesInDecks > 0).Sum(c => c.AmountNonGolden);
+                        havingGolden = group.Where(c => c.CopiesInDecks > 0).Sum(c => c.AmountGolden);
+                    }
+                    else
+                    {
+                        maxCardsAmount = group.Sum(c => c.MaxAmountInCollection);
+                        havingNonGolden = group.Sum(c => c.AmountNonGolden);
+                        havingGolden = group.Sum(c => c.AmountGolden);
+                    }
+
+                    double nonGoldenAverageValue = (maxCardsAmount > 0 ? ((double)havingNonGolden / maxCardsAmount) : 1)
                         * CardDisenchantValue[currentRarity] * CardProbabilities[currentRarity];
-
-                    int havingGolden = group.Sum(c => c.AmountGolden);
-                    double goldenAverageValue = ((double)havingGolden / maxCardsAmount)
+                    
+                    double goldenAverageValue = (maxCardsAmount > 0 ? ((double)havingGolden / maxCardsAmount) : 1)
                         * GoldenCardDisenchantValue[currentRarity] * GoldenCardProbabilities[currentRarity];
 
                     totalAvgDustValue += nonGoldenAverageValue + goldenAverageValue;

--- a/Hearthstone Collection Tracker/packages.config
+++ b/Hearthstone Collection Tracker/packages.config
@@ -4,4 +4,5 @@
   <package id="Fody" version="1.29.4" targetFramework="net45" developmentDependency="true" />
   <package id="MahApps.Metro" version="1.1.2.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="QuickConverter" version="1.2.5" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I've added a setting and functionality to allow users to use their decks in the Deck Tracker for their desired cards list instead of the current manually-maintained one. The goal of this feature is that users will be able to determine the best packs to open to get cards that they actually need for their decks that they are missing cards in. They will be able to switch back and forth as they wish, and this will not cause them to lose their custom desired amounts.

A quick overview of what it does: Whenever a user imports their collection from Hearthstone, or whenever they add/modify/delete a deck inside the Hearthstone Deck Tracker, it will scan all of their non-Arena decks saved in the deck tracker to get a list of all of the cards played in the decks and the highest number of copies needed in any deck. Then it will record those values in their collection and use them for the desired cards values as long as the user has the option enabled.

Note: There are some commits merged in from the 0.8.0 tag. For some reason that never got merged in to master, so I've merged the changes in. I haven't changed any functionality from those files.

Please let me know if you have any questions!