### PR TITLE
Use AppVeyor VS2017 image to support C# 7 features

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ version: v{build}
 max_jobs: 1
 configuration: Release
 clone_depth: 50
+image: Visual Studio 2017
 before_build:
 - cmd: bootstrap.bat
 build:


### PR DESCRIPTION
HearthDb uses C# 7 features currently failing the build.