### PR TITLE
Resolved QuickConverter error

### DIFF
--- a/Hearthstone Collection Tracker/Controls/SetSummary.xaml
+++ b/Hearthstone Collection Tracker/Controls/SetSummary.xaml
@@ -1,13 +1,14 @@
 ﻿<UserControl x:Class="Hearthstone_Collection_Tracker.Controls.SetSummary"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:internal="clr-namespace:Hearthstone_Collection_Tracker.Internal"
              xmlns:hct="clr-namespace:Hearthstone_Collection_Tracker"
-             mc:Ignorable="d" 
+             mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="250">
     <UserControl.Resources>
+        <internal:InverseBooleanConverter x:Key="InverseBooleanConverter" />
         <internal:PercentageConverter x:Key="PercentageConverter" />
         <internal:VisibilityConverter x:Key="VisibilityConverter" />
         <internal:ToUpperValueConverter x:Key="ToUpperConverter" />
@@ -24,9 +25,9 @@
                             <ColumnDefinition Width="Auto"></ColumnDefinition>
                             <ColumnDefinition Width="Auto" SharedSizeGroup="TotalDesiredCardsColumn"></ColumnDefinition>
                         </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" Text="{Binding PlayerHasDesired}" HorizontalAlignment="Right"/>
+                        <TextBlock Grid.Column="0" Text="{Binding PlayerHasDesired}" HorizontalAlignment="Right" />
                         <TextBlock Grid.Column="1">/</TextBlock>
-                        <TextBlock Grid.Column="2" Text="{Binding TotalDesiredAmount}" HorizontalAlignment="Left"/>
+                        <TextBlock Grid.Column="2" Text="{Binding TotalDesiredAmount}" HorizontalAlignment="Left" />
                     </Grid>
                 </DataTemplate>
             </DataGridTemplateColumn.CellTemplate>
@@ -54,12 +55,12 @@
                                         <ColumnDefinition Width="Auto"></ColumnDefinition>
                                         <ColumnDefinition Width="Auto" SharedSizeGroup="TotalCardsColumn"></ColumnDefinition>
                                     </Grid.ColumnDefinitions>
-                                    <TextBlock Grid.Column="0" Text="{Binding PlayerHas}" HorizontalAlignment="Right" ToolTip="Non-Golden"/>
+                                    <TextBlock Grid.Column="0" Text="{Binding PlayerHas}" HorizontalAlignment="Right" ToolTip="Non-Golden" />
                                     <TextBlock Grid.Column="1">/</TextBlock>
                                     <TextBlock Grid.Column="2" Text="{Binding PlayerHasGolden}" Foreground="DarkOrange" HorizontalAlignment="Center"
-                                               ToolTip="Golden"/>
+                                               ToolTip="Golden" />
                                     <TextBlock Grid.Column="3">/</TextBlock>
-                                    <TextBlock Grid.Column="4" Text="{Binding TotalAmount}" HorizontalAlignment="Left" ToolTip="Total"/>
+                                    <TextBlock Grid.Column="4" Text="{Binding TotalAmount}" HorizontalAlignment="Left" ToolTip="Total" />
                                 </Grid>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
@@ -87,7 +88,7 @@
                                     </TextBlock>
                                     <TextBlock Grid.Column="4" Text="{Binding OpenDesiredOdds, Converter={StaticResource PercentageConverter}}"
                                                Visibility="{Binding Path=EnableDesiredCardsFeature, Source={x:Static hct:HearthstoneCollectionTrackerPlugin.Settings}, Converter={StaticResource VisibilityConverter}}"
-                                               HorizontalAlignment="Left" ToolTip="Desired"/>
+                                               HorizontalAlignment="Left" ToolTip="Desired" />
                                 </Grid>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>

--- a/Hearthstone Collection Tracker/Hearthstone Collection Tracker.csproj
+++ b/Hearthstone Collection Tracker/Hearthstone Collection Tracker.csproj
@@ -15,6 +15,7 @@
     <WarningLevel>4</WarningLevel>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -67,9 +68,6 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="QuickConverter, Version=1.2.5.0, Culture=neutral, PublicKeyToken=9c892aa7bc2af2cf, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuickConverter.1.2.5\lib\net40\QuickConverter.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
@@ -120,6 +118,7 @@
     <Compile Include="Internal\Helpers.cs" />
     <Compile Include="Internal\Importing\HearthstoneImporter.cs" />
     <Compile Include="Internal\Importing\ImportingException.cs" />
+    <Compile Include="Internal\InverseBooleanConverter.cs" />
     <Compile Include="Internal\ModuleVersion.cs" />
     <Compile Include="Internal\PercentageConverter.cs" />
     <Compile Include="Internal\PluginSettings.cs" />

--- a/Hearthstone Collection Tracker/Internal/InverseBooleanConverter.cs
+++ b/Hearthstone Collection Tracker/Internal/InverseBooleanConverter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Data;
+
+namespace Hearthstone_Collection_Tracker.Internal
+{
+    /// <summary>
+    /// Returns the inverse of a boolean value.
+    /// Needed because WPF doesn't have a built-in way to check for not values.
+    /// </summary>
+    [ValueConversion(typeof(bool), typeof(bool))]
+    internal class InverseBooleanConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return !(bool)value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException("InverseBooleanConverter is a OneWay converter.");
+        }
+    }
+}

--- a/Hearthstone Collection Tracker/Internal/VisibilityConverter.cs
+++ b/Hearthstone Collection Tracker/Internal/VisibilityConverter.cs
@@ -5,17 +5,39 @@ using System.Windows.Data;
 
 namespace Hearthstone_Collection_Tracker.Internal
 {
-    internal class VisibilityConverter : IValueConverter
+    /// <summary>
+    /// Converts boolean values to Visibility enumerations.
+    /// If all of the values are true, then the control is visible.
+    /// Otherwise, we collapse the control.
+    /// </summary>
+    internal class VisibilityConverter : IMultiValueConverter, IValueConverter
     {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            foreach (var value in values)
+            {
+                if ((value is bool) && (bool)value == false)
+                {
+                    return Visibility.Collapsed;
+                }
+            }
+            return Visibility.Visible;
+        }
+
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             bool visible = (bool)value;
             return visible ? Visibility.Visible : Visibility.Collapsed;
         }
 
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException("VisibilityConverter is a OneWay converter.");
+        }
+
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException("VisibilityConverter is a OneWay converter.");
         }
     }
 }

--- a/Hearthstone Collection Tracker/MainWindow.xaml
+++ b/Hearthstone Collection Tracker/MainWindow.xaml
@@ -7,7 +7,6 @@
         xmlns:DTcontrols="clr-namespace:Hearthstone_Deck_Tracker.Controls;assembly=HearthstoneDeckTracker"
         xmlns:hearthstoneDeckTracker="clr-namespace:Hearthstone_Deck_Tracker;assembly=HearthstoneDeckTracker"
         xmlns:internal="clr-namespace:Hearthstone_Collection_Tracker.Internal"
-        xmlns:qc="http://QuickConverter.CodePlex.com/"
         Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
         Icon="Internal\HSCollection.ico"
         BorderBrush="{DynamicResource AccentColorBrush}" BorderThickness="1"
@@ -67,7 +66,7 @@
                                     <Setter Property="Visibility" Value="Collapsed" />
                                 </Style>
                                 <Style TargetType="ListViewItem">
-                                    <Setter Property="Margin" Value="-4,-3,-3,0"/>
+                                    <Setter Property="Margin" Value="-4,-3,-3,0" />
                                     <Style.Triggers>
                                         <Trigger Property="IsSelected"
                                          Value="True">
@@ -76,13 +75,14 @@
                                         </Trigger>
                                     </Style.Triggers>
                                 </Style>
+                                <internal:InverseBooleanConverter x:Key="InverseBooleanConverter" />
                                 <internal:VisibilityConverter x:Key="VisibilityConverter" />
                             </ListView.Resources>
                             <ListView.GroupStyle>
                                 <GroupStyle>
                                     <GroupStyle.ContainerStyle>
                                         <Style TargetType="{x:Type GroupItem}">
-                                            <Setter Property="Margin" Value="0,0,0,5"/>
+                                            <Setter Property="Margin" Value="0,0,0,5" />
                                             <Setter Property="Template">
                                                 <Setter.Value>
                                                     <ControlTemplate TargetType="{x:Type GroupItem}">
@@ -126,9 +126,14 @@
                                             </hearthstoneDeckTracker:OutlinedTextBlock.Resources>
                                         </hearthstoneDeckTracker:OutlinedTextBlock>
                                         <ComboBox Grid.Column="1" Width="20" SelectedItem="{Binding DesiredAmount, Mode=TwoWay}" Height="25"
-                                                  ToolTip="Desired amount in collection"
-                                                  ItemsSource="{Binding DesiredAmountOptions, Mode=OneTime}"
-                                                  Visibility="{qc:MultiBinding '$P0 ## !$P1 ? Visibility.Visible : Visibility.Collapsed', P0={Binding Path=EnableDesiredCardsFeature, Source={x:Static local:HearthstoneCollectionTrackerPlugin.Settings}}, P1={Binding Path=UseDecksForDesiredCards, Source={x:Static local:HearthstoneCollectionTrackerPlugin.Settings}}}">
+                                                ToolTip="Desired amount in collection"
+                                                ItemsSource="{Binding DesiredAmountOptions, Mode=OneTime}">
+                                            <ComboBox.Visibility>
+                                                <MultiBinding Converter="{StaticResource VisibilityConverter}">
+                                                    <Binding Path="EnableDesiredCardsFeature" Source="{x:Static local:HearthstoneCollectionTrackerPlugin.Settings}" />
+                                                    <Binding Path="UseDecksForDesiredCards" Source="{x:Static local:HearthstoneCollectionTrackerPlugin.Settings}" Converter="{StaticResource InverseBooleanConverter}" />
+                                                </MultiBinding>
+                                            </ComboBox.Visibility>
                                         </ComboBox>
                                     </Grid>
                                 </DataTemplate>
@@ -164,5 +169,5 @@
                 </ItemsControl>
             </WrapPanel>
         </StackPanel>
-    </ScrollViewer>    
+    </ScrollViewer>
 </controls:MetroWindow>

--- a/Hearthstone Collection Tracker/MainWindow.xaml.cs
+++ b/Hearthstone Collection Tracker/MainWindow.xaml.cs
@@ -65,10 +65,6 @@ namespace Hearthstone_Collection_Tracker
 				{
 					Title += " (" + activeAccount + ")";
 				}
-
-                // Setup Quick Converter.
-                QuickConverter.EquationTokenizer.AddNamespace(typeof(object));
-                QuickConverter.EquationTokenizer.AddNamespace(typeof(Visibility));
             }
 			catch(Exception e)
 			{

--- a/Hearthstone Collection Tracker/packages.config
+++ b/Hearthstone Collection Tracker/packages.config
@@ -2,5 +2,4 @@
 <packages>
   <package id="MahApps.Metro" version="1.5.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
-  <package id="QuickConverter" version="1.2.5" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
After the merge I attempted to load the resulting DLL. Whenever I tried to open the plugin it gave this error:
"System.IO.FileNotFoundException: Could not load file or assembly 'QuickConverter, Version=1.2.5.0, Culture=neutral, PublicKeyToken=9c892aa7bc2af2cf' or one of its dependencies. The system cannot find the file specified."

This fix removes the QuickConverter Nuget package and replaces it with a MultiBinding and some modified/added converters. I'm not sure why the error is cropping up now but this resolves it.

I had used QuickConverter to make a MultiBinding on the visibility for the desired amount boxes in collection editor since I was doing multiple checks in it (Only display if we are using the Desired Cards feature and NOT using the Use Decks For Desired feature). It seems to not include the package in the assembly when built so we won't be able to continue using it.

I modified the VisibilityConverter to allow for converting either a single boolean or combining multiple booleans into one Visibility value. I also created an InverseBooleanConverter because bindings don't have a way to check for the opposite value and I needed to check if we're not using the "Use Desired Decks" option. These two changes combined with the MultiBinding gives us the same end result as the QuickConverter binding did.